### PR TITLE
Fix auto-label in `feature_request.md`

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: enhancement
+labels: feature
 assignees: ''
 
 ---


### PR DESCRIPTION
You renamed the default `enhancement` label to `feature`, but did not update the issue template to this change.
Compare [your Template](https://github.com/Facepunch/sbox-issues/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=) against [mine](https://github.com/mozi-h/sbox-issues/issues/new?assignees=&labels=feature&template=feature_request.md&title=).
![grafik](https://user-images.githubusercontent.com/19172408/127779159-fd9cc8e5-b7a8-4314-b2ea-be7f17dc3c6d.png)
